### PR TITLE
LIB-233: Add master pushes to test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,10 @@
 name: tests
-on: [pull_request]
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: bundle exec appraisal rspec
 
       - name: Code Climate
-        run: ./cc-test-reporter after-build --exit-code $?
+        run: ./cc-test-reporter after-build --exit-code $? --id ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
A simple change to make sure to run tests on master pushes. This request came from us playing with the behavior of Github Actions back in May.